### PR TITLE
151 more feedback when dropping

### DIFF
--- a/frontend/src/components/Feature/Diplomadataform/DiplomaDataForm.tsx
+++ b/frontend/src/components/Feature/Diplomadataform/DiplomaDataForm.tsx
@@ -1,5 +1,5 @@
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useEffect, useState } from "react";
 import { TemplateResponse, SaltData, Student, FormDataUpdateRequest, TrackResponse } from "../../../util/types";
 import { FileUpload } from "../../MenuItems/Inputs/FileUploader";
 import { ParseFileData } from '../../../services/InputFileService';
@@ -16,7 +16,6 @@ import { ExclusiveCheckBoxGroup } from "../../MenuItems/Inputs/ExclusiveCheckBox
 import { PublishButton } from "../../MenuItems/Buttons/PublishButton";
 import { TagsInput } from "../../TagsInput/TagsInput";
 
-// Export types
 type FormData = {
   optionA: boolean;
   optionB: boolean;
@@ -36,13 +35,13 @@ type Props = {
 };
 
 export default function DiplomaDataForm({ setSaltData, tracks, templates, UpdateBootcampWithNewFormdata, customAlert, setLoadingMessage, selectedStudentIndex, setSelectedStudentIndex }: Props) {
-
   const { register, handleSubmit, formState: { errors }, watch } = useForm<FormData>();
   const [AllTrackData, setAllTrackData] = useState<TrackResponse[]>();
   const [TrackIndex, setTrackIndex] = useState<number>(0);
   const [BootcampIndex, setBootcampIndex] = useState<number>(0);
   const [students, setStudents] = useState<Student[]>();
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateResponse>();
+  const [attachedFiles, setAttachedFiles] = useState<{ [key: string]: File | null }>({});
 
   useEffect(() => {
     if(tracks && templates){
@@ -61,15 +60,6 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
       setSaltData(saltData);
     }
   }, [students, selectedTemplate]);
-
-  // useEffect(() => {
-  //   if (AllTrackData && templates) {
-  //     const selectedBootcamp = AllTrackData[TrackIndex].bootcamps[BootcampIndex];
-  //     setStudents(selectedBootcamp.students);
-  //     const template = templates?.find(t => t.id === selectedBootcamp.templateId);
-  //     setSelectedTemplate(template);
-  //   }
-  // }, [TrackIndex, BootcampIndex, AllTrackData]);
 
   useEffect(() => {
     if (AllTrackData && templates) {
@@ -93,6 +83,9 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
       verificationCode: generateVerificationCode()
     }));
     setStudents(updatedStudents);
+
+    const bootcampGuid = AllTrackData[TrackIndex].bootcamps[BootcampIndex].guidId;
+    setAttachedFiles({ ...attachedFiles, [bootcampGuid]: file });
   };
 
   const postSelectedBootcampData = async (both?: Boolean) => {
@@ -195,7 +188,6 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
 
   return (
     <form className="diploma-making-form" onSubmit={handleSubmit(onSubmit)}>
-      {/* Select Track */}
       <div className="diploma-making-form__select-track diploma-making-form__select-container">
         <label htmlFor="track" className="diploma-making-form__label">
           Track group
@@ -206,7 +198,6 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
             selectClassOverride='overview-page__select-box'
             options={[
               ...AllTrackData.filter(track => track.bootcamps.length > 0).map((track, idx) => ({
-                // value: track.id.toString(),
                 value: idx.toString(),
                 label: track.name
               }))
@@ -218,7 +209,6 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
           />
         }
       </div>
-      {/* Select bootcamp Class */}
       <div className="diploma-making-form__select-bootcamp diploma-making-form__select-container">
         <label htmlFor="bootcamp" className="diploma-making-form__label">
           Bootcamp
@@ -243,7 +233,6 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
         }
       </div>
 
-      {/* Select Template name */}
       <div className="diploma-making-form__select-template diploma-making-form__select-container">
         <label htmlFor="template" className="diploma-making-form__label">
           Applied Template
@@ -268,7 +257,6 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
         }
       </div>
 
-      {/* Display student data */}
       <div className="diploma-making-form__student-data diploma-making-form__select-container">
         <div className="diploma-making-form__student-data__label-wrapper">
           <label htmlFor="students" className="diploma-making-form__label">
@@ -287,21 +275,13 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
             />
           }
           <div className="diploma-making-form__upload--fileupload-wrapper">
-            <FileUpload FileHandler={handleFileUpload} />
+            {AllTrackData && 
+              <FileUpload FileHandler={handleFileUpload} attachedFile={attachedFiles[AllTrackData[TrackIndex].bootcamps[BootcampIndex].guidId]} />
+            }
           </div>
         </div>
       </div>
 
-      {/* <div className="diploma-making-form__upload diploma-making-form__select-container">
-        <label htmlFor="upload" className="diploma-making-form__label diploma-making-form__label--mb">
-          Upload Student Information
-        </label>
-        <div className="diploma-making-form__upload--fileupload-wrapper">
-          <FileUpload FileHandler={handleFileUpload} />
-        </div>
-      </div> */}
-
-      {/* Checkboxes */}
       <div className="pdf-generation-options">
         <div className="diploma-making-form__checkboxes">
           <label htmlFor="upload" className="diploma-making-form__label diploma-making-form__label--mb">
@@ -326,7 +306,6 @@ export default function DiplomaDataForm({ setSaltData, tracks, templates, Update
           {errors.optionA && <p className="diploma-making-form__error">{errors.optionA.message}</p>}
         </div>
 
-        {/* Radio Group for PDF Generation Scope */}
         <div className="diploma-making-form__radio-group">
           <div className="diploma-making-form__radio-options">
             <ExclusiveCheckBoxGroup

--- a/frontend/src/components/MenuItems/Inputs/FileUploader.css
+++ b/frontend/src/components/MenuItems/Inputs/FileUploader.css
@@ -35,7 +35,7 @@
         box-shadow: 0 0 10px #1575fb6e, 0 0 45px #1575fb88; */
         background-color: #f6522b;
         border-radius: 100%;
-        box-shadow: 0 0 10px #f6522b6e, 0 0 45px #f6522b88;
+        box-shadow: 0 0 10px #f6542b60, 0 0 45px #f6542b6f;
 
         transition: all .2s ease-in-out;
     }
@@ -71,5 +71,29 @@
         border-radius: 100%;
         box-shadow: 0 0 10px #fb15156e, 0 0 45px #fb151588;
 
+        transition: all .2s ease-in-out;
+    }
+
+    
+.fileupload-wrapper.file-active .fileupload__icon-wrapper {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #1e82d4;
+    border-radius: 100%;
+    box-shadow: 0 0 10px #1d93f462, 0 0 45px #1e82d472;
+
+    transition: all .2s ease-in-out;
+}
+    .fileupload-wrapper.file-active .fileupload__icon-wrapper svg {
+        transform: scale(1.15);
+        transition: all .2s ease-in-out;
+    }
+
+    .fileupload-wrapper .fileupload__icon-wrapper svg {
+        width: 50%;
+        height: 50%;
         transition: all .2s ease-in-out;
     }

--- a/frontend/src/components/MenuItems/Inputs/FileUploader.tsx
+++ b/frontend/src/components/MenuItems/Inputs/FileUploader.tsx
@@ -9,9 +9,12 @@ type Props = {
 
 export const FileUpload = ({ FileHandler }: Props) => {
   const [isFileValid, setIsFileValid] = useState<boolean | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
-    FileHandler(acceptedFiles[0]);
+    const file = acceptedFiles[0];
+    FileHandler(file);
+    setFileName(file.name);
     setIsFileValid(null); 
   }, [FileHandler]);
 
@@ -44,17 +47,17 @@ export const FileUpload = ({ FileHandler }: Props) => {
   });
 
   return (
-    <div className="fileupload-wrapper" {...getRootProps()}>
+    <div className={`fileupload-wrapper ${fileName ? 'file-active' : ''}`} {...getRootProps()}>
       <input {...getInputProps()} />
       <>
         <div className={'fileupload__icon-wrapper ' + (isDragActive ? (isFileValid ? 'valid' : 'invalid') : 'normal')}>
           <AddIcon />
         </div>
         <h4 className='fileupload_title'>
-          {isDragActive ? (isFileValid ? 'Valid File' : 'Invalid File Format') : 'Add new File'}
+          {fileName ? `Change file` : isDragActive ? (isFileValid ? 'Valid File' : 'Invalid File Format') : 'Add new File'}
         </h4>
         <p className='fileupload_section'>
-          {isDragActive ? (isFileValid ? 'Drag & drop' : 'File should be .csv, .xlsx or .json') : 'Drag & drop .csv .xlsx or .json'}
+          {fileName ? `${fileName} loaded` : isDragActive ? (isFileValid ? 'Drag & drop' : 'File should be .csv, .xlsx or .json') : 'Drag & drop .csv .xlsx or .json'}
         </p>
       </>
     </div>

--- a/frontend/src/components/MenuItems/Inputs/FileUploader.tsx
+++ b/frontend/src/components/MenuItems/Inputs/FileUploader.tsx
@@ -1,15 +1,25 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import './FileUploader.css';
 import { AddIcon } from '../Icons/AddIcon';
 
 type Props = {
-  FileHandler: (file: File) => void
+  FileHandler: (file: File) => void;
+  attachedFile?: File | null;
 }
 
-export const FileUpload = ({ FileHandler }: Props) => {
+export const FileUpload = ({ FileHandler, attachedFile }: Props) => {
   const [isFileValid, setIsFileValid] = useState<boolean | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (attachedFile) {
+      setFileName(attachedFile.name);
+    } else {
+      setFileName(null);
+      setIsFileValid(null);
+    }
+  }, [attachedFile]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     const file = acceptedFiles[0];

--- a/frontend/src/components/MenuItems/Inputs/PdfFileUpload.css
+++ b/frontend/src/components/MenuItems/Inputs/PdfFileUpload.css
@@ -85,3 +85,21 @@
 
         transition: all .2s ease-in-out;
     }
+
+    .fileupload__icon-wrapper.file-active {
+        width: 40px;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: #1e82d4;
+        border-radius: 100%;
+        box-shadow: 0 0 10px #1d93f462, 0 0 45px #1e82d472;
+      
+        transition: all .2s ease-in-out;
+      }
+      
+      .fileupload__icon-wrapper.file-active svg {
+        transform: scale(1.15);
+        transition: all .2s ease-in-out;
+      }

--- a/frontend/src/components/MenuItems/Inputs/PdfFileUpload.tsx
+++ b/frontend/src/components/MenuItems/Inputs/PdfFileUpload.tsx
@@ -13,25 +13,28 @@ type Props = {
 
 export const PdfFileUpload = ({ fileResult, setFileAdded, fileAdded }: Props) => {
   const [isFileValid, setIsFileValid] = useState<boolean | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
 
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     const file = acceptedFiles[0];
     const isValid = file.type === 'application/pdf';
-
+  
     setIsFileValid(isValid);
-
+  
     if (isValid) {
       const arrayBuffer = await file.arrayBuffer();
       const pdfDoc = await PDFDocument.load(arrayBuffer);
-
+  
       const resizedPdfBytes = await pdfDoc.save();
       const resizedFile = new File([resizedPdfBytes], file.name, { type: file.type });
-
+  
       fileResult(resizedFile);
+      setFileName(file.name);
       if (setFileAdded) {
         setFileAdded(true);
       }
     } else {
+      setFileName(null);
       if (setFileAdded) {
         setFileAdded(false);
       }
@@ -65,20 +68,16 @@ export const PdfFileUpload = ({ fileResult, setFileAdded, fileAdded }: Props) =>
   });
 
   return (
-    <div className="fileupload-wrapper" {...getRootProps()}>
+    <div className={`fileupload-wrapper ${fileName ? 'file-active' : ''}`} {...getRootProps()}>
       <input {...getInputProps()} />
-      <div className={'fileupload__icon-wrapper ' + (fileAdded ? ' fileadded' : isDragActive ? (isFileValid ? 'valid ' : 'invalid ') : 'normal ')}>
-        {fileAdded ? 
-          <RefreshIcon />
-        : 
-          <AddIcon />
-        }
+      <div className={'fileupload__icon-wrapper ' + (fileName ? 'file-active' : isDragActive ? (isFileValid ? 'valid' : 'invalid') : 'normal')}>
+        {fileAdded ? <RefreshIcon /> : <AddIcon />}
       </div>
       <h4 className='fileupload_title'>
-        {isDragActive ? (isFileValid ? 'Valid File' : 'Invalid File Format') : (fileAdded ? 'Change existing PDF' : 'Add new PDF')}
+        {fileName ? `${fileName}` : isDragActive ? (isFileValid ? 'Valid File' : 'Invalid File Format') : 'Add new PDF'}
       </h4>
       <p className='fileupload_section'>
-        {isDragActive ? (isFileValid ? ('Drag & drop') : ('File should be .pdf')) : (fileAdded ? 'Drag & drop' : 'Drag & drop')}
+        {fileName ? 'Change file' : isDragActive ? (isFileValid ? 'Drag & drop' : 'File should be .pdf') : 'Drag & drop .pdf'}
       </p>
     </div>
   );

--- a/frontend/src/components/MenuItems/Inputs/PdfFileUpload.tsx
+++ b/frontend/src/components/MenuItems/Inputs/PdfFileUpload.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import './PdfFileUpload.css';
 import { RefreshIcon } from '../Icons/RefreshIcon';
@@ -6,14 +6,25 @@ import { AddIcon } from '../Icons/AddIcon';
 import { PDFDocument } from 'pdf-lib';
 
 type Props = {
-  fileResult: (file: File) => void
-  setFileAdded?: (added: boolean) => void
-  fileAdded?: boolean
+  fileResult: (file: File) => void;
+  setFileAdded?: (added: boolean) => void;
+  reset?: boolean;
+  setReset?: (value: boolean) => void;
 }
 
-export const PdfFileUpload = ({ fileResult, setFileAdded, fileAdded }: Props) => {
+export const PdfFileUpload = ({ fileResult, setFileAdded, reset, setReset }: Props) => {
   const [isFileValid, setIsFileValid] = useState<boolean | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (reset) {
+      setIsFileValid(null);
+      setFileName(null);
+      if (setReset) {
+        setReset(false);
+      }
+    }
+  }, [reset, setReset]);
 
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     const file = acceptedFiles[0];
@@ -71,7 +82,7 @@ export const PdfFileUpload = ({ fileResult, setFileAdded, fileAdded }: Props) =>
     <div className={`fileupload-wrapper ${fileName ? 'file-active' : ''}`} {...getRootProps()}>
       <input {...getInputProps()} />
       <div className={'fileupload__icon-wrapper ' + (fileName ? 'file-active' : isDragActive ? (isFileValid ? 'valid' : 'invalid') : 'normal')}>
-        {fileAdded ? <RefreshIcon /> : <AddIcon />}
+        {!reset ? <RefreshIcon /> : <AddIcon />}
       </div>
       <h4 className='fileupload_title'>
         {fileName ? `${fileName}` : isDragActive ? (isFileValid ? 'Valid File' : 'Invalid File Format') : 'Add new PDF'}

--- a/frontend/src/pages/TemplateCreator/TemplateCreatorPage.tsx
+++ b/frontend/src/pages/TemplateCreator/TemplateCreatorPage.tsx
@@ -61,6 +61,7 @@ export const TemplateCreatorPage = ({ templates, addNewTemplate, updateTemplate,
   const { loadingMessage } = useLoadingMessage();
 
   const [firstRun, setFirstRun] = useState<boolean>(true)
+  const [resetFileUpload, setResetFileUpload] = useState<boolean>(false);
 
   const [templateStyle, setTemplateStyle] = useState<TemplateInstanceStyle>({
     positionX: null,
@@ -311,6 +312,7 @@ useEffect(() => {
       setFileAdded(false);
       setCurrentTemplate(templateData[index] || null);
       setTemplateIndex(index);
+      setResetFileUpload(true);
     }
   };
 
@@ -363,6 +365,7 @@ useEffect(() => {
           setCurrentTemplate(templateData[goToIndex] || null);
           setTemplateIndex(goToIndex);
           setFileAdded(false);
+          setResetFileUpload(true);
         }
       } catch (error) {
         customAlert('fail',"Template Update failure!",`${error} when trying to update template.`);
@@ -384,6 +387,7 @@ useEffect(() => {
         await addNewTemplate(createBlankTemplate(inputContent));
         customAlert('success',"Succesfully added new template!",`Successfully added new template to database.`);
         setTemplateAdded(true);
+        setResetFileUpload(true);
       } catch (error) {
         customAlert('fail',"Template add failure!",`${error} when trying to add new template to database.`);
       }
@@ -393,7 +397,6 @@ useEffect(() => {
   };
 
   const removeTemplate = async () => {
-    
     if (currentTemplate?.id) {
       closeConfirmationPopup();
       customAlert('loading',"Removing Template...",``);
@@ -407,6 +410,7 @@ useEffect(() => {
         setTemplateIndex(0);
         customAlert('message',"Template Successfully Deleted!", `Successfully deleted ${currentTemplate.templateName} from database`);
         setTemplateHasChanged(false);
+        setResetFileUpload(true);
       } catch (error) {
         customAlert('fail',"Template Update failure!",`${error} when trying to update template.`);
       }
@@ -649,7 +653,8 @@ useEffect(() => {
                             <h3>Add PDF Background</h3>
                             <PdfFileUpload
                                 fileResult={(file: File) => pdfFileUploadHandler(file)}
-                                fileAdded={fileAdded}
+                                reset={resetFileUpload}
+                                setReset={setResetFileUpload}
                                 setFileAdded={setFileAdded}
                             />
                         </section>


### PR DESCRIPTION
**FileUpload:**
- Now has blue tone & shows filename of file that has been added
- Tracks the file loaded into each bootcamp if switching between bootcamps during browsing session

**PDFFileUpload:**
- Shows up in similar blue tone to FileUpload with filename
- Resets when logical on the templateCreatorPage