### PR TITLE
231 integration tests backend

### DIFF
--- a/Backend/DiplomaMakerApi.Tests.Integration/DiplomaMakerApi.Tests.Integration.csproj
+++ b/Backend/DiplomaMakerApi.Tests.Integration/DiplomaMakerApi.Tests.Integration.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.1" />
     <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.4" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
+    <PackageReference Include="Google.Apis.Gmail.v1" Version="1.68.0.3427" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
@@ -1,0 +1,16 @@
+using System.Net.Http.Headers;
+using Xunit;
+
+namespace DiplomaMakerApi.Tests.Integration.EmailController
+{
+    public class CreateEmailControllerTests : IClassFixture<DiplomaMakerApiFactory>
+    {
+        private readonly HttpClient _client;
+
+        public CreateEmailControllerTests(DiplomaMakerApiFactory apiFactory)
+        {
+            _client = apiFactory.CreateClient();
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", "test-token");
+        }
+    }
+}

--- a/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using DiplomaMakerApi.Models;
 using FluentAssertions;
 using Xunit;
 
@@ -9,11 +10,34 @@ namespace DiplomaMakerApi.Tests.Integration.EmailController
     public class CreateEmailControllerTests : IClassFixture<DiplomaMakerApiFactory>
     {
         private readonly HttpClient _client;
-
+        private readonly string _testBlobFolder;
         public CreateEmailControllerTests(DiplomaMakerApiFactory apiFactory)
         {
             _client = apiFactory.CreateClient();
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", "test-token");
+            _testBlobFolder = apiFactory.TestBlobFolder;
+        }
+
+        [Fact]
+        public async Task CreateEmailControllerTests_SendsEmail_WhenDataIsvalid()
+        {
+            // Arrange
+            var studentSetup = await _client.GetAsync("api/Students");
+            var studentSetupResponse = await studentSetup.Content.ReadFromJsonAsync<List<StudentResponseDto>>();
+            var pdfFile = TestUtil.GetFileContent("Default", ".pdf", _testBlobFolder, "DiplomaPdfs");
+            var pdfFormFile = TestUtil.ConvertToIFormFile(pdfFile, "Default.pdf", "application/pdf");
+            var emailRequest = new SendEmailRequest()
+            {
+                File = pdfFormFile,
+                Title = "testTitle",
+                Description = "testDescription"
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync($"api/Email/email-student/{studentSetupResponse![0].GuidId}", emailRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
 
         [Fact]
@@ -21,6 +45,7 @@ namespace DiplomaMakerApi.Tests.Integration.EmailController
         {
             // Arrange
             _client.DefaultRequestHeaders.Authorization = null;
+
             // Act
             var response = await _client.PostAsJsonAsync($"api/Email/email-student/{Guid.NewGuid()}", new object{});
 

--- a/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
@@ -1,4 +1,7 @@
+using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
 using Xunit;
 
 namespace DiplomaMakerApi.Tests.Integration.EmailController
@@ -11,6 +14,18 @@ namespace DiplomaMakerApi.Tests.Integration.EmailController
         {
             _client = apiFactory.CreateClient();
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", "test-token");
+        }
+
+        [Fact]
+        public async Task CreateEmailControllerTests_ReturnsUnathorized_WhenInvalidToken()
+        {
+            // Arrange
+            _client.DefaultRequestHeaders.Authorization = null;
+            // Act
+            var response = await _client.PostAsJsonAsync($"api/Email/email-student/{Guid.NewGuid()}", new object{});
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
     }
 }

--- a/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
@@ -20,7 +20,11 @@ namespace DiplomaMakerApi.Tests.Integration.EmailController
             _googleAuthService = new GoogleAuthService();
         }
 
-        // TO PASS THIS TEST YOU NEED TO LOGIN THROUGH GOGLE AUTH
+        // Work in progress to make this pass... It gets stuck on THE LAST PART OF EMAILSERVICE
+        // "Request had insufficient authentication scopes."
+        // The account through gcloud is missing the emailsend scopes. So we somehow need to add it or authenticate through the gmail api
+
+        // how far i got.
         // step 1 - Install gcloud
         // step 2 - Login through terminal -> gcloud auth login
         // step 3 - Check if logged in -> gcloud auth list
@@ -28,50 +32,50 @@ namespace DiplomaMakerApi.Tests.Integration.EmailController
             // if https://www.googleapis.com/auth/gmail.send is not listed under scopes
         // step 5 - 
 
-        [Fact]
-        public async Task CreateEmailControllerTests_SendsRealEmail_WhenDataIsValid()
-        {
-            // Arrange
-            var studentSetup = await _client.GetAsync("api/Students");
-            var studentSetupResponse = await studentSetup.Content.ReadFromJsonAsync<List<StudentResponseDto>>();
-            var loggedInUserEmail = await _googleAuthService.GetGoogleEmailAsync();
+        // [Fact]
+        // public async Task CreateEmailControllerTests_SendsRealEmail_WhenDataIsValid()
+        // {
+        //     // Arrange
+        //     var studentSetup = await _client.GetAsync("api/Students");
+        //     var studentSetupResponse = await studentSetup.Content.ReadFromJsonAsync<List<StudentResponseDto>>();
+        //     var loggedInUserEmail = await _googleAuthService.GetGoogleEmailAsync();
 
-            var newStudentRequest = new StudentUpdateRequestDto()
-            {
-                Name = "Bob Ryder",
-                Email = loggedInUserEmail
-            };
+        //     var newStudentRequest = new StudentUpdateRequestDto()
+        //     {
+        //         Name = "Bob Ryder",
+        //         Email = loggedInUserEmail
+        //     };
             
-            await _client.PutAsJsonAsync($"api/Students/{studentSetupResponse![0].GuidId}", newStudentRequest);
+        //     await _client.PutAsJsonAsync($"api/Students/{studentSetupResponse![0].GuidId}", newStudentRequest);
 
-            var pdfFile = TestUtil.GetFileContent("Default", ".pdf", _testBlobFolder, "DiplomaPdfs");
-            var pdfFormFile = TestUtil.ConvertToIFormFile(pdfFile, "Default.pdf", "application/pdf");
+        //     var pdfFile = TestUtil.GetFileContent("Default", ".pdf", _testBlobFolder, "DiplomaPdfs");
+        //     var pdfFormFile = TestUtil.ConvertToIFormFile(pdfFile, "Default.pdf", "application/pdf");
 
-            var googleToken = await _googleAuthService.GetGoogleOAuthTokenAsync();
-            var emailRequestContent = new MultipartFormDataContent
-            {
-                { new StreamContent(pdfFormFile.OpenReadStream())
-                    {
-                        Headers = { ContentType = new MediaTypeHeaderValue("application/pdf") }
-                    }, 
-                    "File", pdfFormFile.FileName 
-                }
-            };
+        //     var googleToken = await _googleAuthService.GetGoogleOAuthTokenAsync();
+        //     var emailRequestContent = new MultipartFormDataContent
+        //     {
+        //         { new StreamContent(pdfFormFile.OpenReadStream())
+        //             {
+        //                 Headers = { ContentType = new MediaTypeHeaderValue("application/pdf") }
+        //             }, 
+        //             "File", pdfFormFile.FileName 
+        //         }
+        //     };
 
-            var response = await _client.PostAsync(
-                $"api/Email/email-student/{studentSetupResponse![0].GuidId}?Title=testTitle&Description=testDescription&googleToken={googleToken}", 
-                emailRequestContent
-            );
+        //     var response = await _client.PostAsync(
+        //         $"api/Email/email-student/{studentSetupResponse![0].GuidId}?Title=testTitle&Description=testDescription&googleToken={googleToken}", 
+        //         emailRequestContent
+        //     );
 
-            if (response.StatusCode != HttpStatusCode.OK)
-            {
-                var errorContent = await response.Content.ReadAsStringAsync();
-                Console.WriteLine("Error Message: " + errorContent);
-            }
+        //     if (response.StatusCode != HttpStatusCode.OK)
+        //     {
+        //         var errorContent = await response.Content.ReadAsStringAsync();
+        //         Console.WriteLine("Error Message: " + errorContent);
+        //     }
 
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-        }
+        //     // Assert
+        //     response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // }
 
         [Fact]
         public async Task CreateEmailControllerTests_ReturnsUnathorized_WhenInvalidToken()

--- a/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
@@ -34,15 +34,19 @@ namespace DiplomaMakerApi.Tests.Integration.EmailController
             // Arrange
             var studentSetup = await _client.GetAsync("api/Students");
             var studentSetupResponse = await studentSetup.Content.ReadFromJsonAsync<List<StudentResponseDto>>();
+            var loggedInUserEmail = await _googleAuthService.GetGoogleEmailAsync();
+
             var newStudentRequest = new StudentUpdateRequestDto()
             {
                 Name = "Bob Ryder",
-                Email = "william.f.lindberg@hotmail.com"
+                Email = loggedInUserEmail
             };
+            
             await _client.PutAsJsonAsync($"api/Students/{studentSetupResponse![0].GuidId}", newStudentRequest);
 
             var pdfFile = TestUtil.GetFileContent("Default", ".pdf", _testBlobFolder, "DiplomaPdfs");
             var pdfFormFile = TestUtil.ConvertToIFormFile(pdfFile, "Default.pdf", "application/pdf");
+
             var googleToken = await _googleAuthService.GetGoogleOAuthTokenAsync();
             var emailRequestContent = new MultipartFormDataContent
             {

--- a/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/EmailController/CreateEmailControllerTests.cs
@@ -11,30 +11,59 @@ namespace DiplomaMakerApi.Tests.Integration.EmailController
     {
         private readonly HttpClient _client;
         private readonly string _testBlobFolder;
+        private readonly GoogleAuthService _googleAuthService;
         public CreateEmailControllerTests(DiplomaMakerApiFactory apiFactory)
         {
             _client = apiFactory.CreateClient();
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", "test-token");
             _testBlobFolder = apiFactory.TestBlobFolder;
+            _googleAuthService = new GoogleAuthService();
         }
 
+        // TO PASS THIS TEST YOU NEED TO LOGIN THROUGH GOGLE AUTH
+        // step 1 - Install gcloud
+        // step 2 - Login through terminal -> gcloud auth login
+        // step 3 - Check if logged in -> gcloud auth list
+        // step 4 - List what scopes your account has -> gcloud auth application-default print-access-token | xargs -I {} curl -H "Authorization: Bearer {}" https://www.googleapis.com/oauth2/v1/tokeninfo
+            // if https://www.googleapis.com/auth/gmail.send is not listed under scopes
+        // step 5 - 
+
         [Fact]
-        public async Task CreateEmailControllerTests_SendsEmail_WhenDataIsvalid()
+        public async Task CreateEmailControllerTests_SendsRealEmail_WhenDataIsValid()
         {
             // Arrange
             var studentSetup = await _client.GetAsync("api/Students");
             var studentSetupResponse = await studentSetup.Content.ReadFromJsonAsync<List<StudentResponseDto>>();
+            var newStudentRequest = new StudentUpdateRequestDto()
+            {
+                Name = "Bob Ryder",
+                Email = "william.f.lindberg@hotmail.com"
+            };
+            await _client.PutAsJsonAsync($"api/Students/{studentSetupResponse![0].GuidId}", newStudentRequest);
+
             var pdfFile = TestUtil.GetFileContent("Default", ".pdf", _testBlobFolder, "DiplomaPdfs");
             var pdfFormFile = TestUtil.ConvertToIFormFile(pdfFile, "Default.pdf", "application/pdf");
-            var emailRequest = new SendEmailRequest()
+            var googleToken = await _googleAuthService.GetGoogleOAuthTokenAsync();
+            var emailRequestContent = new MultipartFormDataContent
             {
-                File = pdfFormFile,
-                Title = "testTitle",
-                Description = "testDescription"
+                { new StreamContent(pdfFormFile.OpenReadStream())
+                    {
+                        Headers = { ContentType = new MediaTypeHeaderValue("application/pdf") }
+                    }, 
+                    "File", pdfFormFile.FileName 
+                }
             };
 
-            // Act
-            var response = await _client.PostAsJsonAsync($"api/Email/email-student/{studentSetupResponse![0].GuidId}", emailRequest);
+            var response = await _client.PostAsync(
+                $"api/Email/email-student/{studentSetupResponse![0].GuidId}?Title=testTitle&Description=testDescription&googleToken={googleToken}", 
+                emailRequestContent
+            );
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync();
+                Console.WriteLine("Error Message: " + errorContent);
+            }
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/Backend/DiplomaMakerApi.Tests.Integration/GoogleAuthService.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/GoogleAuthService.cs
@@ -1,0 +1,20 @@
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Gmail.v1;
+public class GoogleAuthService
+{
+    public async Task<string> GetGoogleOAuthTokenAsync()
+    {
+        GoogleCredential credential = await GoogleCredential.GetApplicationDefaultAsync();
+        if (credential.IsCreateScopedRequired)
+        {
+            credential = credential.CreateScoped(new[]
+            {
+                GmailService.Scope.GmailSend,
+                "https://www.googleapis.com/auth/userinfo.email",
+                "https://www.googleapis.com/auth/userinfo.profile"
+            });
+        }
+        var token = await credential.UnderlyingCredential.GetAccessTokenForRequestAsync();
+        return token;
+    }
+}

--- a/Backend/DiplomaMakerApi.Tests.Integration/GoogleAuthService.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/GoogleAuthService.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Gmail.v1;
 public class GoogleAuthService
@@ -16,5 +18,39 @@ public class GoogleAuthService
         }
         var token = await credential.UnderlyingCredential.GetAccessTokenForRequestAsync();
         return token;
+    }
+
+    public async Task<string> GetGoogleEmailAsync()
+    {
+        GoogleCredential credential = await GoogleCredential.GetApplicationDefaultAsync();
+        if (credential.IsCreateScopedRequired)
+        {
+            credential = credential.CreateScoped(new[]
+            {
+                GmailService.Scope.GmailSend,
+                "https://www.googleapis.com/auth/userinfo.email",
+                "https://www.googleapis.com/auth/userinfo.profile"
+            });
+        }
+        var token = await credential.UnderlyingCredential.GetAccessTokenForRequestAsync();
+
+        using (var httpClient = new HttpClient())
+        {
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var response = await httpClient.GetAsync("https://www.googleapis.com/oauth2/v2/userinfo");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var userInfo = await response.Content.ReadFromJsonAsync<GoogleUserInfo>();
+                return userInfo!.Email;
+            }
+
+            throw new Exception("Unable to retrieve Google user info.");
+        }
+    }
+
+    public class GoogleUserInfo
+    {
+        public required string Email { get; set; }
     }
 }

--- a/Backend/DiplomaMakerApi.Tests.Integration/TestUtil.cs
+++ b/Backend/DiplomaMakerApi.Tests.Integration/TestUtil.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 
 namespace DiplomaMakerApi.Tests.Integration
 {
@@ -33,6 +34,16 @@ namespace DiplomaMakerApi.Tests.Integration
             fileContent.Should().NotBeEmpty($"File {templateName}{extension} should not be empty at {filePath}");
 
             return fileContent;
+        }
+
+        public static IFormFile ConvertToIFormFile(byte[] fileBytes, string fileName, string contentType)
+        {
+            var stream = new MemoryStream(fileBytes);
+            return new FormFile(stream, 0, stream.Length, "file", fileName)
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = contentType
+            };
         }
 
         private static string GetFilePath(string templateName, string extension, string testBlobDirectory, string subDirectory)


### PR DESCRIPTION
**CreateEmailControllerTests**
- CreateEmailControllerTests_ReturnsUnathorized_WhenInvalidToken

**Problems: CreateEmailControllerTests_SendsRealEmail_WhenDataIsValid**
- Tried to use gcloud to add scope to currently logged in account but google does not like that
- Tried authenticating via credentials.json from googleApi but could not get it to work